### PR TITLE
Add python deserialization error messages

### DIFF
--- a/python/dslib.py
+++ b/python/dslib.py
@@ -37,15 +37,23 @@ class Context(object):
         self._canceled_timers: List[str] = list()
 
     def send(self, msg: Message, to: str):
+        if not isinstance(to, str):
+            raise TypeError('to argument has to be string, not {}'.format(type(to)))
         self._sent_messages.append((msg.type, json.dumps(msg._data), to))
 
     def send_local(self, msg: Message):
         self._sent_local_messages.append((msg.type, json.dumps(msg._data)))
 
     def set_timer(self, timer_id: str, delay: float):
+        if not isinstance(timer_id, str):
+            raise TypeError('timer_id argument has to be str, not {}'.format(type(timer_id)))
+        if not isinstance(delay, (int, float)):
+            raise TypeError('delay argument has to be int or float, not {}'.format(type(delay)))
         self._set_timers.append((timer_id, delay))
     
     def cancel_timer(self, timer_id: str):
+        if not isinstance(timer_id, str):
+            raise TypeError('timer_id argument has to be str, not {}'.format(type(timer_id)))
         self._canceled_timers.append(timer_id)
 
     def time(self) -> float:


### PR DESCRIPTION
Сейчас при передаче невалидных типов в функции, случается паника с сообщением, в котором не содержится название функции, которая была вызвана с невалидными типами. А еще не помешал бы трейс в питоне

До:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: PyErr { type: <class 'TypeError'>, value: TypeError("'builtin_function_or_method' object cannot be converted to 'PyString'"), traceback: None }', /Users/darkkeks/Documents/distsys-homework/dslib/src/pynode.rs:100:101
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

После:
```
!!! Error when calling Python code:

Traceback (most recent call last):
  File "solution.py", line 21, in on_local_message
  File "/Users/darkkeks/Documents/distsys-homework/dslib/python/dslib.py", line 49, in set_timer
    raise TypeError('timer_id argument has to be str, not {}'.format(type(timer_id)))
TypeError: timer_id argument has to be str, not <class 'builtin_function_or_method'>

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: PyErr { type: <class 'TypeError'>, value: TypeError("timer_id argument has to be str, not <class 'builtin_function_or_method'>"), traceback: Some(<traceback object at 0x10e529300>) }', /Users/darkkeks/Documents/distsys-homework/dslib/src/pynode.rs:133:16
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```