### PR TITLE
Use absolute path for python modules

### DIFF
--- a/src/pynode.rs
+++ b/src/pynode.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Error, Formatter};
 use std::fs;
-use std::path::Path;
 use std::rc::Rc;
 use pyo3::prelude::*;
 use pyo3::types::{PyModule, PyTuple};
@@ -50,7 +49,8 @@ pub struct PyNodeFactory {
 impl PyNodeFactory {
     pub fn new(node_path: &str, node_class: &str) -> Self {
         let node_code = fs::read_to_string(node_path).unwrap();
-        let node_filename = Path::new(node_path).file_name().unwrap().to_str().unwrap();
+        let node_realpath = fs::canonicalize(node_path).unwrap();
+        let node_filename = node_realpath.to_str().unwrap();
         let node_module = node_filename.replace(".py", "");
         let classes = Python::with_gil(|py| -> (PyObject, PyObject, PyObject) {
             let node_module = PyModule::from_code(


### PR DESCRIPTION
Для импортированных python-модулей используется полный абсолютный путь.

Причины, по которым это может быть полезно:
 - В коде теперь можно использовать `__file__` (например, для чтения / импорта файлов, для которых известен путь относительно текущего модуля)
 - Такое же поведение (абсолютный путь в `__file__`) наблюдается при импорте модуля средствами стандартной библиотеки ([начиная с python 3.4](https://docs.python.org/3/whatsnew/3.4.html#other-language-changes)).